### PR TITLE
[Week9] 스레드 찍먹하기

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,11 @@ dependencies {
     // LiveData
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.4.1"
 
+    //socket
+    implementation ('io.socket:socket.io-client:2.0.0') {
+        exclude group: 'org.json', module: 'json'
+    }
+
     def room_version = "2.4.2"
     // Room
     kapt "androidx.room:room-compiler:$room_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,11 +17,6 @@
             android:name=".presentation.coroutine.WorkManagerActivity"
             android:exported="true" >
 
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
 
         </activity>
         <activity
@@ -40,6 +35,11 @@
         <activity
             android:name=".presentation.save.screens.FriendActivity"
             android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".presentation.sign.screens.LoginActivity"

--- a/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/FriendActivity.kt
+++ b/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/FriendActivity.kt
@@ -1,28 +1,26 @@
 package com.sopt.androidstudy.presentation.save.screens
 
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.repeatOnLifecycle
 import com.sopt.androidstudy.R
-import com.sopt.androidstudy.data.datasources.FriendDataSources
 import com.sopt.androidstudy.data.model.UserData
 import com.sopt.androidstudy.data.model.db.Friend
-import com.sopt.androidstudy.data.model.db.FriendDatabase
-import com.sopt.androidstudy.data.repository.FriendRepositoryImpl
 import com.sopt.androidstudy.databinding.ActivitySaveBinding
 import com.sopt.androidstudy.presentation.save.adapter.FriendRecyclerViewAdapter
 import com.sopt.androidstudy.presentation.save.viewmodels.FriendViewModel
+import com.sopt.androidstudy.presentation.sign.screens.BindingConversions
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
+import io.socket.client.Socket.EVENT_CONNECT_ERROR
+import io.socket.emitter.Emitter
+import io.socket.engineio.client.EngineIOException
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.net.Socket
 
 @AndroidEntryPoint
 class FriendActivity : AppCompatActivity() {
@@ -36,6 +34,7 @@ class FriendActivity : AppCompatActivity() {
         //로그인시 내 계정 정보 받아오기. 아직은 안씀
         initBindingView()
         displayFriendsList()
+        //ClientThread().start()
     }
 
 
@@ -44,10 +43,32 @@ class FriendActivity : AppCompatActivity() {
         binding.myViewModel = friendViewModel
         binding.lifecycleOwner = this
         friendAdapter = FriendRecyclerViewAdapter(::selectFriend)
+        //val socket = BindingConversions.get()
+
+        /*socket.on("lightOn", emitOn)
+        socket.on("lightOff", emitOn)
+        socket.on(io.socket.client.Socket.EVENT_CONNECT) {
+            // 소켓 서버에 연결이 성공하면 호출됩니다.
+            Log.i("Socket", "Connect")
+        }.on(io.socket.client.Socket.EVENT_DISCONNECT) { args ->
+            // 소켓 서버 연결이 끊어질 경우에 호출됩니다.
+            Log.i("Socket", "Disconnet: ${args[0]}")
+        }.on(EVENT_CONNECT_ERROR) { args ->
+            // 소켓 서버 연결 시 오류가 발생할 경우에 호출됩니다.
+            var errorMessage = ""
+            if (args[0] is EngineIOException) {
+                errorMessage = "code: ${args[0].toString()}"
+            }
+            Log.i("Socket", "Connect Error: $errorMessage")
+        }*/
+        //socket.connect()
         initEvent()
         binding.mainRcv.adapter = friendAdapter
     }
-
+    val emitOn = Emitter.Listener {
+        Log.d("why?", it.toString())
+        binding.mbtiText.text = it[0].toString()
+    }
     private fun initEvent() {
         friendViewModel.showToast.observe(this) {
             it.getContentIfNotHandled()?.let {
@@ -59,13 +80,31 @@ class FriendActivity : AppCompatActivity() {
                 ).show()
             }
         }
-    }
+    }/*
+    inner class ClientThread : Thread() {
+        override fun run() {
+            val host = "10.2.2"
+            val port = 8000
+            try {
+                val socket = Socket(host, port)
+                val outstream = ObjectOutputStream(socket.getOutputStream())
+                outstream.writeObject("Hello!")
+                outstream.flush()
+                Log.d("ClientStream", "Sent to server.")
+                val instream = ObjectInputStream(socket.getInputStream())
+                val input: Any = instream.readObject()
+                Log.d("ClientThread", "Received data: $input")
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }*/
 
     private fun selectFriend(friend: Friend) {
         friendViewModel.selectFriend(friend = friend)
         //이전 기능 포함
         val intent = Intent(this@FriendActivity, FriendGithubActivity::class.java).apply {
-            putExtra("username", friendViewModel.friend.value?.name)
+            putExtra("username", "KkamSonLee")
         }
         startActivity(intent)
     }

--- a/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/FriendGithubActivity.kt
+++ b/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/FriendGithubActivity.kt
@@ -87,11 +87,12 @@ class FriendGithubActivity : AppCompatActivity() {
         }
         bindingView()
         friendGithubViewModel.selectUser.observe(this) {
-            val message = myThreadHandler.obtainMessage()
             val bundle = Bundle()
             bundle.putString("string", it.avatar_url)
-            message.data = bundle
-            message.what = IMAGE_WHAT
+            val message = myThreadHandler.obtainMessage().apply {
+                        data = bundle
+                        what = IMAGE_WHAT
+            }
             myThreadHandler.sendMessage(message)
         }
     }

--- a/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/FriendGithubActivity.kt
+++ b/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/FriendGithubActivity.kt
@@ -126,14 +126,15 @@ class FriendGithubActivity : AppCompatActivity() {
     inner class MyHandler : Handler(Looper.getMainLooper()) {
         override fun handleMessage(msg: Message) {
             val bundle = msg.data
-            if (msg.what == COUNT_WHAT) {
-                val count = bundle.getInt("count")
-                binding.mbti.text = count.toString()
-            } else if (msg.what == IMAGE_WHAT) {
-                val stringBitmap = bundle.getString("bitmap")
-                stringBitmap?.let {
-                    binding.imageView.post {
-                        binding.imageView.setImageBitmap(convertBitmap.stringToBitmap(it))
+            when (msg.what) {
+                COUNT_WHAT -> {
+                    val count = bundle.getInt("count")
+                    binding.count.text = count.toString()
+                }
+                IMAGE_WHAT -> {
+                    val stringBitmap = bundle.getString("bitmap") ?: return
+                    binding.profileImage.post {
+                        binding.profileImage.setImageBitmap(ConvertBitmap().stringToBitmap(stringBitmap))
                     }
                 }
             }

--- a/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/FriendGithubActivity.kt
+++ b/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/FriendGithubActivity.kt
@@ -1,25 +1,27 @@
 package com.sopt.androidstudy.presentation.save.screens
 
-import androidx.appcompat.app.AppCompatActivity
-import android.os.Bundle
-import android.widget.Toast
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.os.*
+import android.util.Base64
+import android.util.Log
 import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.sopt.androidstudy.R
-import com.sopt.androidstudy.data.remote.ServiceCreator
 import com.sopt.androidstudy.databinding.ActivityFriendGithubBinding
 import com.sopt.androidstudy.presentation.save.screens.fragment.Follwer
 import com.sopt.androidstudy.presentation.save.screens.fragment.Repo
 import com.sopt.androidstudy.presentation.save.viewmodels.FriendGithubViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import java.io.*
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlin.concurrent.thread
+
 
 class FriendGithubActivity : AppCompatActivity() {
 
@@ -29,28 +31,76 @@ class FriendGithubActivity : AppCompatActivity() {
     lateinit var user: String
     var isEnabled = true
     val friendGithubViewModel: FriendGithubViewModel by viewModels()
+
+    //For Thread
+    var i = 0
+    val countThread = thread(start = false) {
+        while (true) {
+            i++
+            val bundle = Bundle()
+            val message = myHandler.obtainMessage()
+            SystemClock.sleep(1000)
+            bundle.putInt("count", i)
+            message.data = bundle
+            message.what = COUNT_WHAT
+            myHandler.sendMessage(message)
+        }
+    }
+
+    val myHandler = MyHandler()
+    val backgroundHadlerThread = HandlerThread("HandlerThread")
+    lateinit var myThreadHandler: MyThreadHandler
+    //val background1Thread = Background1Thread(myHandler)
+
+
+    //lateinit var socket: Socket
+    //val myThread: ExecutorService = Executors.newFixedThreadPool(8)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         user = intent.getStringExtra("username").toString()
+        //ServerThread().start()
         binding = DataBindingUtil.setContentView(this, R.layout.activity_friend_github)
         user.let {
             friendGithubViewModel.setUserName(user)
             lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     friendGithubViewModel.getUserData.collect {
+                        Log.d("Collect!!", it.toString())
                         binding.user = it
                     }
                 }
             }
         }
+        backgroundHadlerThread.start()
+        myThreadHandler = MyThreadHandler()
+        binding.imageView.setOnClickListener {
+            if (countThread.isAlive) {
+                i = 0
+                Log.d("is Alive", countThread.toString())
+                countThread.interrupt()
+                if (!countThread.isAlive) {
+                    countThread.start()
+                }
+            } else {
+                countThread.start()
+            }
+        }
         bindingView()
+        friendGithubViewModel.selectUser.observe(this) {
+            val message = myThreadHandler.obtainMessage()
+            val bundle = Bundle()
+            bundle.putString("string", it.avatar_url)
+            message.data = bundle
+            message.what = IMAGE_WHAT
+            myThreadHandler.sendMessage(message)
+        }
     }
 
     private fun bindingView() {
-
-        binding.btnFollower.isEnabled = isEnabled
-        binding.btnRepo.isEnabled = !isEnabled
-
+        /*socket = BindingConversions.get()
+        socket.connect()*/
+        binding.btnFollower.isEnabled = !isEnabled
+        binding.btnRepo.isEnabled = isEnabled
         supportFragmentManager.beginTransaction()
             .add(R.id.fragContainerGithub, myFragments[0])
             .commit()
@@ -71,4 +121,168 @@ class FriendGithubActivity : AppCompatActivity() {
             binding.btnRepo.isEnabled = !isEnabled
         }
     }
+
+    inner class MyHandler : Handler(Looper.getMainLooper()) {
+        override fun handleMessage(msg: Message) {
+            val bundle = msg.data
+            if (msg.what == COUNT_WHAT) {
+                val count = bundle.getInt("count")
+                binding.mbti.text = count.toString()
+            } else if (msg.what == IMAGE_WHAT) {
+                val stringBitmap = bundle.getString("bitmap")
+                stringBitmap?.let {
+                    binding.imageView.post {
+                        binding.imageView.setImageBitmap(convertBitmap.stringToBitmap(it))
+                    }
+                }
+            }
+        }
+    }
+
+    inner class MyThreadHandler : Handler(backgroundHadlerThread.looper) {
+        override fun handleMessage(msg: Message) {
+            val bundle: Bundle = msg.data
+            if (msg.what == IMAGE_WHAT) {
+                val stringBitmap = bundle.getString("string")
+                val bitmap =
+                    stringBitmap?.let { convertBitmap.getBitmapFromURL(it) }
+                stringBitmap?.let {
+                    binding.imageView.post {
+                        binding.imageView.setImageBitmap(bitmap)
+                    }
+                }
+                SystemClock.sleep(1000)
+            }
+        }
+    }
+
+    /*inner class Background2Thread : Thread() {
+        override fun run() {
+            val bitmap =
+                convertBitmap.getBitmapFromURL("https://avatars.githubusercontent.com/u/15981307?v=4")
+            val bundle = Bundle()
+            val message = myHandler.obtainMessage()
+            bundle.putString("bitmap",
+                bitmap?.let { it1 -> convertBitmap.bitmapToString(it1) })
+            message.data = bundle
+            myHandler.sendMessage(message)
+        }
+    }
+
+    inner class ServerThread : Thread() {
+        override fun run() {
+            val port = 8000
+            try {
+                val server = ServerSocket(port)
+                Log.d("ServerThread", "Server Started.")
+                while (true) {
+                    val socket: java.net.Socket = server.accept()
+                    val instream = ObjectInputStream(socket.getInputStream())
+                    val input: Any = instream.readObject()
+                    Log.d("ServerThread", "input: $input")
+                    val outstream = ObjectOutputStream(socket.getOutputStream())
+                    outstream.writeObject("$input from server.")
+                    outstream.flush()
+                    Log.d("ServerThread", "output sent.")
+                    socket.close()
+                }
+            } catch (e: java.lang.Exception) {
+                e.printStackTrace()
+            }
+        }
+    }*/
+
+    companion object {
+        const val COUNT_WHAT = 1
+        const val IMAGE_WHAT = 2
+    }
 }
+
+object convertBitmap {
+    fun getBitmapFromURL(src: String): Bitmap? {
+        return try {
+            val url = URL(src)
+            val connection: HttpURLConnection = url.openConnection() as HttpURLConnection
+            connection.doInput = true
+            connection.connect()
+            val input: InputStream = connection.inputStream
+            BitmapFactory.decodeStream(input)
+        } catch (e: IOException) {
+            e.printStackTrace()
+            null
+        }
+    }
+
+    fun bitmapToString(bitmap: Bitmap): String {
+        val baos =
+            ByteArrayOutputStream() //바이트 배열을 차례대로 읽어 들이기위한 ByteArrayOutputStream클래스 선언
+        bitmap.compress(Bitmap.CompressFormat.PNG, 70, baos) //bitmap을 압축 (숫자 70은 70%로 압축한다는 뜻)
+        val bytes = baos.toByteArray() //해당 bitmap을 byte배열로 바꿔준다.
+        return Base64.encodeToString(bytes, Base64.DEFAULT) //Base 64 방식으로byte 배열을 String으로 변환
+    }
+
+    fun stringToBitmap(encodedString: String?): Bitmap? {
+        return try {
+            val encodeByte: ByteArray = Base64.decode(
+                encodedString,
+                Base64.DEFAULT
+            ) // String 화 된 이미지를  base64방식으로 인코딩하여 byte배열을 만듬
+            BitmapFactory.decodeByteArray(
+                encodeByte,
+                0,
+                encodeByte.size
+            ) //byte배열을 bitmapfactory 메소드를 이용하여 비트맵으로 바꿔준다.
+            //만들어진 bitmap을 return
+        } catch (e: Exception) {
+            e.message
+            null
+        }
+    }
+}
+
+/*class myThreadHandler:Runnable{
+    override fun run() {
+        Looper.prepare()
+
+        val bitmap =
+        try {
+            val url = URL("https://avatars.githubusercontent.com/u/90037701?v=4")
+            val connection: HttpURLConnection = url.openConnection() as HttpURLConnection
+            connection.doInput = true
+            connection.connect()
+            val input: InputStream = connection.inputStream
+            BitmapFactory.decodeStream(input)
+        } catch (e: IOException) {
+            e.printStackTrace()
+            null
+        }
+    }
+
+}*/
+/*fun uploadUserData(avatarUrl: String) {
+        var bitmap: Bitmap? = null
+        //Thread(myRunnable())
+
+        *//* myThread.submit {
+             bitmap = getBitmapFromURL(avatarUrl)
+             //Log.d("Bitmap", bitmap.toString())
+             binding.imageView.post {
+                 bitmap?.let {
+                     binding.imageView.setImageBitmap(it)
+                 }
+                 //binding.imageView.setImageBitmap(call.call())
+             }
+         }*//*
+        //Thread{}
+        *//*val call= myThread.submit {
+            Callable {
+                getBitmapFromURL(avatarUrl)
+            }
+        }
+        call.get()?.let {
+            runOnUiThread {
+                Log.d("get!!!!!", it.toString())
+                binding.imageView.setImageBitmap(it as Bitmap)
+            }
+        }*//*
+    }*/

--- a/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/fragment/FollowerAdapter.kt
+++ b/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/fragment/FollowerAdapter.kt
@@ -8,25 +8,28 @@ import androidx.recyclerview.widget.RecyclerView
 import com.sopt.androidstudy.data.remote.github.models.ResponseFollowing
 import com.sopt.androidstudy.databinding.ItemSampleListBinding
 
-class FollowerAdapter :
+class FollowerAdapter(val itemClickListener: (ResponseFollowing)->Unit) :
     ListAdapter<ResponseFollowing, FollowerAdapter.MyViewHolder>(FollowerDiffUtil) {
 
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MyViewHolder {
         val binding =
             ItemSampleListBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return MyViewHolder(binding)
+        return MyViewHolder(binding, itemClickListener = itemClickListener)
     }
 
     override fun onBindViewHolder(holder: MyViewHolder, position: Int) {
         holder.onBind(getItem(position))
     }
 
-    class MyViewHolder(private val binding: ItemSampleListBinding) :
+    class MyViewHolder(private val binding: ItemSampleListBinding, private val itemClickListener: (ResponseFollowing) -> Unit) :
         RecyclerView.ViewHolder(binding.root) {
         fun onBind(data: ResponseFollowing) {
             with(binding) {
                 follower = data
+                clParent.setOnClickListener {
+                    itemClickListener(data)
+                }
             }
         }
     }

--- a/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/fragment/Follwer.kt
+++ b/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/fragment/Follwer.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.sopt.androidstudy.data.remote.github.models.ResponseFollowing
 import com.sopt.androidstudy.databinding.FragmentFollwerBinding
 import com.sopt.androidstudy.presentation.save.viewmodels.FriendGithubViewModel
 import kotlinx.coroutines.launch
@@ -34,7 +35,7 @@ class Follwer : Fragment() {
     }
 
     private fun bindingView() {
-        adapter = FollowerAdapter()
+        adapter = FollowerAdapter { profileViewModel.selectFollower(it) }
         binding.recyclerFollower.addItemDecoration(
             DividerItemDecoration(
                 context,
@@ -51,13 +52,12 @@ class Follwer : Fragment() {
     }
 
     private fun displayFollowingList() {
-       /* lifecycleScope.launch {
+        lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 profileViewModel.getFollower.collect {
                     adapter.submitList(it)
                 }
             }
-
-        }*/
+        }
     }
 }

--- a/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/fragment/Follwer.kt
+++ b/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/fragment/Follwer.kt
@@ -51,14 +51,13 @@ class Follwer : Fragment() {
     }
 
     private fun displayFollowingList() {
-        lifecycleScope.launch {
+       /* lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 profileViewModel.getFollower.collect {
-                    Log.d("Follower - ", "collect!!")
                     adapter.submitList(it)
                 }
             }
 
-        }
+        }*/
     }
 }

--- a/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/fragment/Repo.kt
+++ b/app/src/main/java/com/sopt/androidstudy/presentation/save/screens/fragment/Repo.kt
@@ -46,15 +46,14 @@ class Repo : Fragment() {
     }
 
     private fun displayFollowingList() {
-        lifecycleScope.launch {
+        /*lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 profileViewModel.getRepository.collect {
-                    Log.d("Repo - ", "collect!!")
                     adapter.submitList(it)
                 }
             }
 
-        }
+        }*/
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/sopt/androidstudy/presentation/save/viewmodels/FriendGithubViewModel.kt
+++ b/app/src/main/java/com/sopt/androidstudy/presentation/save/viewmodels/FriendGithubViewModel.kt
@@ -3,7 +3,6 @@ package com.sopt.androidstudy.presentation.save.viewmodels
 import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.asFlow
 import androidx.lifecycle.viewModelScope
 import com.sopt.androidstudy.data.remote.ServiceCreator
 import com.sopt.androidstudy.data.remote.github.models.ResponseFollowing
@@ -12,8 +11,7 @@ import com.sopt.androidstudy.data.remote.github.models.ResponseUser
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.flow.stateIn
-import retrofit2.Call
-import retrofit2.Response
+import kotlin.concurrent.thread
 
 class FriendGithubViewModel : ViewModel() {
     private val userName = MutableLiveData<String>()
@@ -33,13 +31,15 @@ class FriendGithubViewModel : ViewModel() {
                 }.body()
                 if (responseUser != null) {
                     emit(responseUser)
+                    userData()
                 }
                 Log.d("user : emit!!", responseUser.toString())
             }
-            delay(2000)
+            delay(30000)
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
+    fun userData(): String? = getUserData.value?.avatar_url
     val getRepository: StateFlow<List<ResponseRepo>?> = flow {
         if (!userName.value.isNullOrBlank()) {
             val responseRepository = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/sopt/androidstudy/presentation/save/viewmodels/FriendViewModel.kt
+++ b/app/src/main/java/com/sopt/androidstudy/presentation/save/viewmodels/FriendViewModel.kt
@@ -8,6 +8,7 @@ import com.sopt.androidstudy.domain.repository.FriendRepository
 import com.sopt.androidstudy.presentation.util.Event
 import com.sopt.androidstudy.presentation.util.safeValueOf
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/app/src/main/java/com/sopt/androidstudy/presentation/sign/screens/BindingConversions.kt
+++ b/app/src/main/java/com/sopt/androidstudy/presentation/sign/screens/BindingConversions.kt
@@ -7,9 +7,12 @@ import androidx.databinding.BindingAdapter
 import coil.load
 import coil.transform.CircleCropTransformation
 import com.sopt.androidstudy.R
+import io.socket.client.IO
+import io.socket.client.Socket
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.net.URISyntaxException
 
 object BindingConversions {
     @JvmStatic
@@ -30,4 +33,17 @@ object BindingConversions {
             }
         }
     }
+
+    /*@JvmStatic
+    private lateinit var socket: Socket
+
+    @JvmStatic
+    fun get(): Socket {
+        try {
+            socket = IO.socket("http://10.0.2.2:8000")
+        } catch (e: URISyntaxException) {
+            e.printStackTrace()
+        }
+        return socket
+    }*/
 }

--- a/app/src/main/res/layout/activity_friend_github.xml
+++ b/app/src/main/res/layout/activity_friend_github.xml
@@ -27,7 +27,6 @@
             android:layout_width="100dp"
             android:layout_height="100dp"
             android:layout_marginTop="20dp"
-            load="@{user.avatar_url!=null?user.avatar_url:context.getText(R.string.avatar_url)}"
             app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -42,11 +41,11 @@
             android:textSize="20sp" />
 
         <TextView
-
+            android:id="@+id/handler"
             style="@style/Widget.TitleTextView.Style"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{user.location}"
+            tools:text="@{user.location}"
             android:textColor="@color/gray_400" />
 
         <TextView

--- a/app/src/main/res/layout/activity_save.xml
+++ b/app/src/main/res/layout/activity_save.xml
@@ -40,15 +40,14 @@
             android:text="@={myViewModel.inputEmail}"
             app:layout_constraintTop_toBottomOf="@id/my_name_text" />
 
-        <EditText
+        <TextView
             android:id="@+id/mbti_text"
+            style="@style/Widget.TitleTextView.Style"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginTop="20dp"
-            android:hint="친구 MBTI"
-            android:inputType="text"
-            android:text="@={myViewModel.inputMBTI}"
+            android:text="서버 통신을 기다리는중입니다."
             app:layout_constraintTop_toBottomOf="@id/email_text" />
 
         <Button

--- a/app/src/main/res/layout/item_sample_list.xml
+++ b/app/src/main/res/layout/item_sample_list.xml
@@ -10,6 +10,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/cl_parent"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="10dp">


### PR DESCRIPTION
## Keypoint
- 카운터 초기화 처리
- 사진 전환 실행 순서 보장
- handler class들 inner 키워드 없앨 수 있는데 없앤걸로 못 올렸네요... 암시적 참조 조심합시다.

### 카운터 초기화 처리
- 코틀린 제공 thread block 사용
```kotlin
    var i = 0  // 초기값
    val countThread = thread(start = false) {  // 선언 시에는 start = false 아직 사용안함
        while (true) {  // 무한 루프 돌리기
            i++
            val bundle = Bundle()
            val message = myHandler.obtainMessage()
            SystemClock.sleep(1000)   //왜 여기에 sleep을 넣었죠 여튼 sendMessage 전에만 하면 됩니다.
            bundle.putInt("count", i)
            message.data = bundle
            message.what = COUNT_WHAT  //count_what이라는 상수 선언해둠 1임
            myHandler.sendMessage(message)
        }
    }
```
- 초기화 로직
- 현재 isAlive이라면 interrupt를 걸어줌
- 일시정지 상태일 때 종료할 수 있음
- isAlive가 false일 때 다시 카운트 시작,
```kotlin
        binding.imageView.setOnClickListener {
            if (countThread.isAlive) {
                i = 0
                countThread.interrupt()
                if (!countThread.isAlive) {
                    countThread.start()
                }
            } else {
                countThread.start()
            }
        }
```
- UI Handler 처리는 동일합니다.

### 사진 전화 실행 순서 보장
- delay 2000 -> 1000로 변경 ( 너무 오래 기다려야함..)
- 팔로워 목록 클릭시 해당 사용자의 이미지로 바꾸게 만들었음
- 기존 문제점, bitmap 이미지 처리는 background에서 해야하는데, 해당 스레드를 여러번 실행 시켰을 때 문제점이 드러남
- 문제 1 : 이미지 변경 때마다 새로운 스레드 생성 -> 각자의 delay를 따로따로 가지고 있어서 갑자기 일괄 적용되는 현상이 일어남
- 문제 2 : 하나의 스레드에서 처리 -> 안 된다. 내부적으로 run만 호출해가지고 현재 실행 중인 스레드에서 또 하나의 run을 실행시 java.lang.illegalthreadstateexception가 터짐
### 해결 방법 (HandlerThread 사용)
- Background Thread에서도 message queue를 가지고 순차 처리를 해주면 된다.


- handlerthread와 해당 handlerThread message 처리용 handler 선언
```kotlin
    val backgroundHadlerThread = HandlerThread("HandlerThread")
    lateinit var myThreadHandler: MyThreadHandler
```
- handlerThread에게 보낼 UI handler의 선언
```kotlin
    inner class MyThreadHandler : Handler(backgroundHadlerThread.looper) {
//backgroundHadlerThread 의 looper를 생성자로 넣어 해당 메세지는 backgroundHandler에서 처리하게 된다. (background)
        override fun handleMessage(msg: Message) {
            val bundle: Bundle = msg.data
            if (msg.what == IMAGE_WHAT) {
                val stringBitmap = bundle.getString("string")
                val bitmap =
                    stringBitmap?.let { convertBitmap.getBitmapFromURL(it) }
                stringBitmap?.let {
                    binding.imageView.post {
                        binding.imageView.setImageBitmap(bitmap)
                    }
                }
                SystemClock.sleep(1000)
            }
        }
    }
```
- 팔로워 선택시
```kotlin
        friendGithubViewModel.selectUser.observe(this) {
            val message = myThreadHandler.obtainMessage()
            val bundle = Bundle()
            bundle.putString("string", it.avatar_url)
            message.data = bundle
            message.what = IMAGE_WHAT
            myThreadHandler.sendMessage(message)  //backgroundHadlerThread looper의 message queue로 넘어감
        }
```

## 실행화면

https://user-images.githubusercontent.com/15981307/184095118-779736f1-7fbf-4e01-95b1-7e8d6ffd6977.mov

### 참고할점
- 이번주 제가 조금 빠듯해서 설명을 자세히 못 쓴점 죄송합니다 ㅜㅜ 혹시라도 의문점 있다면 다 말씀해주세요!!
- 그리고 이미 있는 코드에서 해당 기능을 구현하다보니 file changed에서 보려면 상당히 코드가 더러울 것 같습니다. 따라서 PR을 주로 참고해주세요
- 연습했던 코드들 아까워서 주석처리 해놓은 것 많습니다. 무시해주세요..!